### PR TITLE
fix: total premine

### DIFF
--- a/app/app-core.sh
+++ b/app/app-core.sh
@@ -140,7 +140,8 @@ app_install_core()
                                           --symbol "$SYMBOL" \
                                           --peers "$MAINNET_PEERS" \
                                           --prefixHash "$MAINNET_PREFIX" \
-                                          --transactionsPerBlock "$TXS_PER_BLOCK"
+                                          --transactionsPerBlock "$TXS_PER_BLOCK" \
+                                          --totalPremine "$TOTAL_PREMINE"
 
     ## Build Devnet
     node "$ROOT_PATH/packages/js-deployer/bin/deployer" --configPath "$CONFIG_PATH_DEVNET" \
@@ -184,7 +185,8 @@ app_install_core()
                                           --symbol "$SYMBOL" \
                                           --peers "$DEVNET_PEERS" \
                                           --prefixHash "$DEVNET_PREFIX" \
-                                          --transactionsPerBlock "$TXS_PER_BLOCK"
+                                          --transactionsPerBlock "$TXS_PER_BLOCK" \
+                                          --totalPremine "$TOTAL_PREMINE"
 
     ## Build Testnet
     node "$ROOT_PATH/packages/js-deployer/bin/deployer" --configPath "$CONFIG_PATH_TESTNET" \
@@ -227,7 +229,8 @@ app_install_core()
                                           --token "$TOKEN" \
                                           --symbol "$SYMBOL" \
                                           --prefixHash "$TESTNET_PREFIX" \
-                                          --transactionsPerBlock "$TXS_PER_BLOCK"
+                                          --transactionsPerBlock "$TXS_PER_BLOCK" \
+                                          --totalPremine "$TOTAL_PREMINE"
 
     rm -rf "$BRIDGECHAIN_PATH"/packages/core/bin/config/{mainnet,devnet,testnet}/
     rm -rf "$BRIDGECHAIN_PATH"/packages/crypto/src/networks/{mainnet,devnet,testnet}/

--- a/config.sample.json
+++ b/config.sample.json
@@ -54,7 +54,6 @@
     "blockTime": 8,
     "transactionsPerBlock": 50,
     "totalPremine": 2100000000000000,
-    "updateEpoch": false,
     "rewardHeightStart": 75600,
     "rewardPerBlock": 200000000,
     "bridgechainPath": "/home/vagrant/core-bridgechain",

--- a/packages/js-deployer/bin/deployer
+++ b/packages/js-deployer/bin/deployer
@@ -39,7 +39,7 @@ commander
   .option('--prefixHash <value>', 'Address Prefix Hash [28]', 28)
   .option('--transactionsPerBlock <value>', 'Max Transaction count per Block [50]', 50)
   .option('--wifPrefix <value>', 'Prefix for generating a WIF [rand(1, 255)]', getRandomNumber(1, 255))
-  .option('--totalPremine <value>', 'Tokens added to genesis wallet [2100000000000000 (21 million)]', 2100000000000000)
+  .option('--totalPremine <value>', 'Tokens added to genesis wallet [2100000000000000 (21 million)]', '2100000000000000')
   .option('--overwriteConfig', 'Overwrite current deployer config files [off]', false)
   .option('--configPath <value>', 'Deployer config path destination')
   .option('--corePath <value>', 'Core path location [~/core-bridgechain]', `${path.resolve(os.homedir(), 'core-bridgechain')}`)

--- a/packages/js-deployer/lib/schema.js
+++ b/packages/js-deployer/lib/schema.js
@@ -36,7 +36,7 @@ module.exports = Joi.object().keys({
     .min(1)
     .max(255)
     .required(),
-  totalPremine: Joi.number().required(),
+  totalPremine: Joi.string().required(),
   configPath: Joi.string().required(),
   // Static Fees
   feeStaticTransfer: Joi.number().required(),

--- a/vagrant/config.json
+++ b/vagrant/config.json
@@ -46,7 +46,6 @@
     "blockTime": 16,
     "transactionsPerBlock": 500,
     "totalPremine": 2100000000000000,
-    "updateEpoch": false,
     "rewardHeightStart": 100,
     "rewardPerBlock": 200000000,
     "bridgechainPath": "/home/vagrant/core-bridgechain",


### PR DESCRIPTION
The pre-mine value wasn't being used at all when deploying chains, so the genesis block always had 21 million tokens.