### PR TITLE
refactor: set epoch in js script

### DIFF
--- a/app/app-core.sh
+++ b/app/app-core.sh
@@ -91,8 +91,6 @@ app_install_core()
     rm -rf "$CONFIG_PATH_MAINNET" "$CONFIG_PATH_DEVNET" "$CONFIG_PATH_TESTNET" "$BRIDGECHAIN_PATH"
     git clone https://github.com/ArkEcosystem/core.git "$BRIDGECHAIN_PATH"
 
-    local EPOCH=$(__get_epoch)
-
     local DYNAMIC_FEE_ENABLED="false"
     if [[ "$FEE_DYNAMIC_ENABLED" == "Y" ]]; then
         local DYNAMIC_FEE_ENABLED="true"
@@ -132,7 +130,6 @@ app_install_core()
                                           --feeDynamicBytesTimelockTransfer "$FEE_DYNAMIC_BYTES_TIMELOCK_TRANSFER" \
                                           --feeDynamicBytesMultiPayment "$FEE_DYNAMIC_BYTES_MULTIPAYMENT" \
                                           --feeDynamicBytesDelegateResignation "$FEE_DYNAMIC_BYTES_DELEGATE_RESIGNATION" \
-                                          --epoch "$EPOCH" \
                                           --rewardHeight "$REWARD_HEIGHT_START" \
                                           --rewardPerBlock "$REWARD_PER_BLOCK" \
                                           --blocktime "$BLOCK_TIME" \
@@ -177,7 +174,6 @@ app_install_core()
                                           --feeDynamicBytesTimelockTransfer "$FEE_DYNAMIC_BYTES_TIMELOCK_TRANSFER" \
                                           --feeDynamicBytesMultiPayment "$FEE_DYNAMIC_BYTES_MULTIPAYMENT" \
                                           --feeDynamicBytesDelegateResignation "$FEE_DYNAMIC_BYTES_DELEGATE_RESIGNATION" \
-                                          --epoch "$EPOCH" \
                                           --rewardHeight "$REWARD_HEIGHT_START" \
                                           --rewardPerBlock "$REWARD_PER_BLOCK" \
                                           --blocktime "$BLOCK_TIME" \
@@ -222,7 +218,6 @@ app_install_core()
                                           --feeDynamicBytesTimelockTransfer "$FEE_DYNAMIC_BYTES_TIMELOCK_TRANSFER" \
                                           --feeDynamicBytesMultiPayment "$FEE_DYNAMIC_BYTES_MULTIPAYMENT" \
                                           --feeDynamicBytesDelegateResignation "$FEE_DYNAMIC_BYTES_DELEGATE_RESIGNATION" \
-                                          --epoch "$EPOCH" \
                                           --rewardHeight "$REWARD_HEIGHT_START" \
                                           --rewardPerBlock "$REWARD_PER_BLOCK" \
                                           --blocktime "$BLOCK_TIME" \
@@ -327,18 +322,6 @@ app_uninstall_core()
     rm -rf "$BRIDGECHAIN_PATH"
 
     success "Uninstall OK!"
-}
-
-__get_epoch()
-{
-    local YEAR=$(date +"%-Y")
-    local MONTH=$(printf "%02d" $(expr $(date +"%-m") - 1))
-    local DAY=$(printf "%02d" $(date +"%-d"))
-    local HOUR=$(printf "%02d" $(date +"%-H"))
-    local MINUTE=$(printf "%02d" $(date +"%-M"))
-    local SECOND=$(printf "%02d" $(date +"%-S"))
-
-    echo "${YEAR}-${MONTH}-${DAY}T${HOUR}:${MINUTE}:${SECOND}.000Z"
 }
 
 __yarn_setup()

--- a/packages/js-deployer/bin/deployer
+++ b/packages/js-deployer/bin/deployer
@@ -29,7 +29,7 @@ commander
   .option('--dbDatabase <value>', 'Database name', `core_${commander.name.toLowerCase()}`)
   .option('--explorerUrl <value>', 'URL to link to explorer', 'http://localhost:4200')
   .option('--forgers <value>', 'How many forgers for the network [51]', 51)
-  .option('--epoch <value>', 'Set Epoch based on time the chain was created', '2017-02-21T13:00:00.000Z')
+  .option('--epoch <value>', 'Set Epoch based on time the chain was created', (new Date()).toISOString())
   .option('--rewardHeight <value>', 'Block Height when Forgers receive Rewards [1]', 1)
   .option('--rewardPerBlock <value>', 'How many Rewarded Tokens per Forged Block [200000000 (2)]', 200000000)
   .option('--blocktime <value>', 'Time per block (seconds) [8]', 8)


### PR DESCRIPTION
A remnant of the v1 deployer was being used to generate the epoch date (when the chain is launched). the problem is, the v1 date needed -1 for the month (E.g. 2 = March, 3 = Apr). This hadn’t been removed for v2, so when deploying in the last few days, the epoch time for a date that didn’t exist was being used (e.g. 2019-02-31 - 31st Feb)