### PR TITLE
refactor: postgres without sudo

### DIFF
--- a/app/app-core.sh
+++ b/app/app-core.sh
@@ -26,13 +26,17 @@ app_install_core()
         TESTNET_PREFIX=$(sh -c "jq '.M' $__dir/prefixes.json")
     fi
 
+    ## Create local user for psql
+    sudo -u postgres psql -c "CREATE USER $USER;"
+    sudo -u postgres psql -c "ALTER USER $USER WITH SUPERUSER;"
+
     local DATABASE_NAME_MAINNET="${DATABASE_NAME}_mainnet"
     local DATABASE_NAME_DEVNET="${DATABASE_NAME}_devnet"
     local DATABASE_NAME_TESTNET="${DATABASE_NAME}_testnet"
 
-    local DB_EXISTS_MAINNET=$(sudo -u postgres psql -t -c "\l" | fgrep "$DATABASE_NAME_MAINNET" | fgrep "|" | awk '{$1=$1};1' | awk '{print $1}')
-    local DB_EXISTS_DEVNET=$(sudo -u postgres psql -t -c "\l" | fgrep "$DATABASE_NAME_DEVNET" | fgrep "|" | awk '{$1=$1};1' | awk '{print $1}')
-    local DB_EXISTS_TESTNET=$(sudo -u postgres psql -t -c "\l" | fgrep "$DATABASE_NAME_TESTNET" | fgrep "|" | awk '{$1=$1};1' | awk '{print $1}')
+    local DB_EXISTS_MAINNET=$(psql -t -c "\l" postgres | fgrep "$DATABASE_NAME_MAINNET" | fgrep "|" | awk '{$1=$1};1' | awk '{print $1}')
+    local DB_EXISTS_DEVNET=$(psql -t -c "\l" postgres | fgrep "$DATABASE_NAME_DEVNET" | fgrep "|" | awk '{$1=$1};1' | awk '{print $1}')
+    local DB_EXISTS_TESTNET=$(psql -t -c "\l" postgres | fgrep "$DATABASE_NAME_TESTNET" | fgrep "|" | awk '{$1=$1};1' | awk '{print $1}')
 
     local DB_EXISTS="$DB_EXISTS_MAINNET $DB_EXISTS_DEVNET $DB_EXISTS_TESTNET"
     local DB_EXISTS=$(echo "$DB_EXISTS" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
@@ -46,22 +50,23 @@ app_install_core()
             echo "Skipping database re-creation"
         else
             if [ ! -z "$DB_EXISTS_MAINNET" ]; then
-                sudo -u postgres dropdb "$DATABASE_NAME_MAINNET"
-                sudo -u postgres createdb "$DATABASE_NAME_MAINNET"
+                dropdb "$DATABASE_NAME_MAINNET"
+                createdb "$DATABASE_NAME_MAINNET"
             fi
             if [ ! -z "$DB_EXISTS_DEVNET" ]; then
-                sudo -u postgres dropdb "$DATABASE_NAME_DEVNET"
-                sudo -u postgres createdb "$DATABASE_NAME_DEVNET"
+                dropdb "$DATABASE_NAME_DEVNET"
+                createdb "$DATABASE_NAME_DEVNET"
             fi
             if [ ! -z "$DB_EXISTS_TESTNET" ]; then
-                sudo -u postgres dropdb "$DATABASE_NAME_TESTNET"
-                sudo -u postgres createdb "$DATABASE_NAME_TESTNET"
+                dropdb "$DATABASE_NAME_TESTNET"
+                createdb "$DATABASE_NAME_TESTNET"
             fi
+            echo "Created databases"
         fi
     else
-        sudo -u postgres createdb "$DATABASE_NAME_MAINNET"
-        sudo -u postgres createdb "$DATABASE_NAME_DEVNET"
-        sudo -u postgres createdb "$DATABASE_NAME_TESTNET"
+        createdb "$DATABASE_NAME_MAINNET"
+        createdb "$DATABASE_NAME_DEVNET"
+        createdb "$DATABASE_NAME_TESTNET"
         echo "Created databases"
     fi
 

--- a/app/args.sh
+++ b/app/args.sh
@@ -69,13 +69,13 @@ parse_json_config()
                     fi
                 ;;
                 "mainnetPrefix")
-                    PREFIX=$(jq -r '.mainnetPrefix' "$CONFIG")
+                    MAINNET_PREFIX=$(jq -r '.mainnetPrefix' "$CONFIG")
                 ;;
                 "devnetPrefix")
-                    PREFIX=$(jq -r '.devnetPrefix' "$CONFIG")
+                    DEVNET_PREFIX=$(jq -r '.devnetPrefix' "$CONFIG")
                 ;;
                 "testnetPrefix")
-                    PREFIX=$(jq -r '.testnetPrefix' "$CONFIG")
+                    TESTNET_PREFIX=$(jq -r '.testnetPrefix' "$CONFIG")
                 ;;
                 "fees")
                     local STATIC_FEES=$(jq -r '.fees.static // empty' "$CONFIG")

--- a/app/process-core.sh
+++ b/app/process-core.sh
@@ -64,7 +64,7 @@ __core_start() {
 __core_check_last_height() {
     local CONFIG_PATH="$1"
     local DATABASE_NAME=$(cat "$BRIDGECHAIN_PATH/packages/core/bin/config/$NETWORK/.env" | fgrep 'CORE_DB_DATABASE=' | awk -F'=' '{print $2}')
-    sudo -u postgres psql -qtAX -d "$DATABASE_NAME" -c "SELECT height FROM blocks ORDER BY height DESC LIMIT 1" 2>/dev/null || echo 0
+    psql -qtAX -d "$DATABASE_NAME" -c "SELECT height FROM blocks ORDER BY height DESC LIMIT 1" 2>/dev/null || echo 0
 }
 
 process_core_stop()


### PR DESCRIPTION
Sets up postgres so sudo isn't needed during core start. This is important because it can impact the starting of core on system reboot.

Also contains a fix for address prefixes per network.