### PR TITLE
fix: ubuntu get ip

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -2,5 +2,5 @@
 
 get_ip()
 {
-    sudo ifconfig | fgrep "inet " | egrep -v "inet (127|192)\." | egrep -o "inet ([0-9]+\.?){4}" | awk '{print $2}' | head -n 1
+    sudo ifconfig | fgrep "inet " | egrep -v "inet (127|192)\." | egrep -o "inet (addr:)?([0-9]+\.?){4}" | awk '{print $2}' | head -n 1
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Fixes issue with ubuntu and the format of ifconfig when getting the IP of the machine.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
