### PR TITLE
refactor: peer script check branch exists after clone

### DIFF
--- a/app/app-core.sh
+++ b/app/app-core.sh
@@ -291,21 +291,21 @@ app_install_core()
 shopt -s expand_aliases
 alias ark="$BRIDGECHAIN_PATH_RAW/packages/core/bin/run"
 echo 'alias $ALIAS="$BRIDGECHAIN_PATH_RAW/packages/core/bin/run"' >> ~/.bashrc
+
 rm -rf "$BRIDGECHAIN_PATH_RAW"
-git clone "$GIT_CORE_ORIGIN" -b chore/bridgechain-changes "$BRIDGECHAIN_PATH_RAW" || FAILED="Y"
-
+git clone "$GIT_CORE_ORIGIN" "$BRIDGECHAIN_PATH_RAW" || FAILED="Y"
 if [ "\$FAILED" == "Y" ]; then
-    FAILED="N"
-    git clone "$GIT_CORE_ORIGIN" "$BRIDGECHAIN_PATH_RAW" || FAILED="Y"
+    echo "Failed to fetch core repo with origin '$GIT_CORE_ORIGIN'"
 
-    if [ "\$FAILED" == "Y" ]; then
-        echo "Failed to fetch core repo with origin '$GIT_CORE_ORIGIN'"
-
-        exit 1
-    fi
+    exit 1
 fi
 
 cd "$BRIDGECHAIN_PATH_RAW"
+HAS_REMOTE=\$(git branch -a | fgrep -o "remotes/origin/chore/bridgechain-changes")
+if [ ! -z "$HAS_REMOTE" ]; then
+    git checkout chore/bridgechain-changes
+fi
+
 YARN_SETUP="N"
 while [ "\$YARN_SETUP" == "N" ]; do
   YARN_SETUP="Y"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

In the modified install.sh script, it would try to clone down `chore/bridgechain-changes` and if that failed it would try to clone `master`. Instead, it now clones down the repo master, and checks if the `chore/bridgechain-changes` branch exists.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Refactor

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
