### PR TITLE
fix: use correct external IP on EC2 instances

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -2,6 +2,9 @@
 
 get_ip()
 {
+if AWS_IP=$(curl -f -s --connect-timeout 5 http://169.254.169.254/2009-04-04/meta-data/public-ipv4); then
+    echo "$AWS_IP"
+else
     IP=$(sudo ifconfig | fgrep "inet " | egrep -v "inet (addr:)?(127|192)\." | egrep -o "inet (addr:)?([0-9]+\.?){4}" | egrep -o "([0-9]+\.?){4}" | head -n 1)
 
     if [ ! -z "$IP" ]; then
@@ -9,6 +12,7 @@ get_ip()
     else
         get_local_ip
     fi
+fi
 }
 
 get_local_ip()

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -2,7 +2,7 @@
 
 get_ip()
 {
-    if AWS_IP=$(curl -f -s --connect-timeout 5 http://169.254.169.254/2009-04-04/meta-data/public-ipv4); then
+    if AWS_IP=$(curl -f -s --connect-timeout 5 http://169.254.169.254/latest/meta-data/public-ipv4); then
         echo "$AWS_IP"
     else
         IP=$(sudo ifconfig | fgrep "inet " | egrep -v "inet (addr:)?(127|192)\." | egrep -o "inet (addr:)?([0-9]+\.?){4}" | egrep -o "([0-9]+\.?){4}" | head -n 1)

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -2,17 +2,17 @@
 
 get_ip()
 {
-if AWS_IP=$(curl -f -s --connect-timeout 5 http://169.254.169.254/2009-04-04/meta-data/public-ipv4); then
-    echo "$AWS_IP"
-else
-    IP=$(sudo ifconfig | fgrep "inet " | egrep -v "inet (addr:)?(127|192)\." | egrep -o "inet (addr:)?([0-9]+\.?){4}" | egrep -o "([0-9]+\.?){4}" | head -n 1)
-
-    if [ ! -z "$IP" ]; then
-        echo "$IP"
+    if AWS_IP=$(curl -f -s --connect-timeout 5 http://169.254.169.254/2009-04-04/meta-data/public-ipv4); then
+        echo "$AWS_IP"
     else
-        get_local_ip
+        IP=$(sudo ifconfig | fgrep "inet " | egrep -v "inet (addr:)?(127|192)\." | egrep -o "inet (addr:)?([0-9]+\.?){4}" | egrep -o "([0-9]+\.?){4}" | head -n 1)
+
+        if [ ! -z "$IP" ]; then
+            echo "$IP"
+        else
+            get_local_ip
+        fi
     fi
-fi
 }
 
 get_local_ip()

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -2,18 +2,16 @@
 
 get_ip()
 {
+    # Specific to AWS EC2 instances. It uses AWS's Instance Metadata service to retrive the external IP. It falls back to using ifconfig on non EC2 machines.
+    # More info: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
     if AWS_IP=$(curl -f -s --connect-timeout 5 http://169.254.169.254/latest/meta-data/public-ipv4); then
         echo "$AWS_IP"
+    elif IP=$(sudo ifconfig | fgrep "inet " | egrep -v "inet (addr:)?(127|192)\." | egrep -o "inet (addr:)?([0-9]+\.?){4}" | egrep -o "([0-9]+\.?){4}" | head -n 1); then
+        echo "$IP"
     else
-        IP=$(sudo ifconfig | fgrep "inet " | egrep -v "inet (addr:)?(127|192)\." | egrep -o "inet (addr:)?([0-9]+\.?){4}" | egrep -o "([0-9]+\.?){4}" | head -n 1)
-
-        if [ ! -z "$IP" ]; then
-            echo "$IP"
-        else
-            get_local_ip
-        fi
+        get_local_ip
     fi
-}
+    }
 
 get_local_ip()
 {


### PR DESCRIPTION
AWS doesn't expose the instance's external IP on `ifconfig`, instead it is exposed through [Instance Metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).This fix will use the correct external IP address when using Deployer on EC2 instances.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
