### PR TITLE
chore: use core 2.5.28 when deploying bridgechains

### DIFF
--- a/app/app-core.sh
+++ b/app/app-core.sh
@@ -105,7 +105,7 @@ app_install_core()
 
     rm -rf "$CONFIG_PATH_MAINNET" "$CONFIG_PATH_DEVNET" "$CONFIG_PATH_TESTNET" "$BRIDGECHAIN_PATH"
 
-    git clone https://github.com/ArkEcosystem/core.git --branch 2.5.26 "$BRIDGECHAIN_PATH"
+    git clone https://github.com/ArkEcosystem/core.git --branch 2.5.28 "$BRIDGECHAIN_PATH"
 
     local DYNAMIC_FEE_ENABLED="false"
     if [[ "$FEE_DYNAMIC_ENABLED" == "Y" ]]; then

--- a/app/update-core.sh
+++ b/app/update-core.sh
@@ -48,7 +48,7 @@ update_core_handle()
 
 update_core_resolve_vars()
 {
-	TARGET_VERSION="2.5.26"
+	TARGET_VERSION="2.5.28"
 	BRIDGECHAIN_BIN=$(jq -r '.oclif.bin' "$BRIDGECHAIN_PATH/packages/core/package.json")
 	CHAIN_VERSION=$(jq -r '.version' "$BRIDGECHAIN_PATH/packages/core/package.json")
 	NETWORKS_PATH="$BRIDGECHAIN_PATH/packages/crypto/src/networks"


### PR DESCRIPTION
Deploy bridgechains using Core 2.5.28.

## What kind of change does this PR introduce?

- [x] Build

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
